### PR TITLE
Upgrade latest target to 2024-12 (1.7.x)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -41,11 +41,11 @@ ANTLR Runtime 3.2
 
  * License: BSD-3-Clause
 
-Apache Commons Logging 1.2.0
+Apache Commons Logging 1.3.4
 
  * License: Apache-2.0
 
-Google Guava 33.3.0
+Google Guava 33.3.1
 
  * License: Apache-2.0
 
@@ -57,7 +57,7 @@ JUnit 4.13.2
 
  * License: EPL-1.0
 
-hamcrest-core 2.2
+hamcrest-core 3.0
 
  * License: BSD-3-Clause
 

--- a/org.eclipse.handly.examples.adapter/example.target
+++ b/org.eclipse.handly.examples.adapter/example.target
@@ -15,7 +15,7 @@
 <target name="Adapter Example">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2024-09"/>
+<repository location="http://download.eclipse.org/releases/2024-12"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.handly.examples.basic/META-INF/MANIFEST.MF
+++ b/org.eclipse.handly.examples.basic/META-INF/MANIFEST.MF
@@ -10,7 +10,6 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.xtext.generator;resolution:=optional,
- org.apache.commons.logging;bundle-version="1.2.0";resolution:=optional,
  org.eclipse.emf.codegen.ecore;resolution:=optional,
  org.eclipse.emf.mwe.utils;resolution:=optional,
  org.eclipse.emf.mwe2.launch;resolution:=optional,
@@ -22,7 +21,8 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.equinox.common;resolution:=optional,
  org.eclipse.xtext.xbase.lib;bundle-version="2.25.0",
  org.objectweb.asm;bundle-version="9.1.0";resolution:=optional
-Import-Package: org.apache.log4j;version="[1.2.15,2.0.0)";resolution:=optional
+Import-Package: org.apache.log4j;version="[1.2.15,2.0.0)";resolution:=optional,
+ org.apache.commons.logging;version="1.2.0";resolution:=optional
 Export-Package: org.eclipse.handly.examples.basic,
  org.eclipse.handly.examples.basic.foo,
  org.eclipse.handly.examples.basic.foo.impl,

--- a/org.eclipse.handly.examples.basic/example.p2f
+++ b/org.eclipse.handly.examples.basic/example.p2f
@@ -16,7 +16,7 @@
   <ius size='1'>
     <iu id='org.eclipse.xtext.sdk.feature.group'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-09'/>
+        <repository location='http://download.eclipse.org/releases/2024-12'/>
       </repositories>
     </iu>
   </ius>

--- a/org.eclipse.handly.examples.basic/example.target
+++ b/org.eclipse.handly.examples.basic/example.target
@@ -15,7 +15,7 @@
 <target name="Basic Example">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2024-09"/>
+<repository location="http://download.eclipse.org/releases/2024-12"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.handly.examples.jmodel.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.handly.examples.jmodel.tests/META-INF/MANIFEST.MF
@@ -9,5 +9,6 @@ Fragment-Host: org.eclipse.handly.examples.jmodel
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.filebuffers,
  org.eclipse.handly.junit,
- org.eclipse.text
+ org.eclipse.text,
+ org.eclipse.jdt.launching
 Import-Package: junit.framework

--- a/org.eclipse.handly.examples.jmodel.tests/src/org/eclipse/handly/internal/examples/jmodel/WorkingCopyTest.java
+++ b/org.eclipse.handly.examples.jmodel.tests/src/org/eclipse/handly/internal/examples/jmodel/WorkingCopyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2022 1C-Soft LLC.
+ * Copyright (c) 2015, 2024 1C-Soft LLC.
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which is available at
@@ -41,6 +41,7 @@ import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.text.edits.DeleteEdit;
 import org.eclipse.text.edits.InsertEdit;
 import org.eclipse.text.edits.ReplaceEdit;
@@ -61,6 +62,7 @@ public class WorkingCopyTest
     protected void setUp() throws Exception
     {
         super.setUp();
+        JavaRuntime.getDefaultVMInstall(); // force VM install initialization
         IProject project = setUpProject("Test010");
         workingCopy = (CompilationUnit)JavaModelCore.createCompilationUnitFrom(
             project.getFile(new Path("src/X.java")));

--- a/org.eclipse.handly.examples.jmodel.tests/workspace/Test010/.classpath
+++ b/org.eclipse.handly.examples.jmodel.tests/workspace/Test010/.classpath
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
     <classpathentry kind="src" path="src"/>
     <classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.handly.examples.jmodel/example.target
+++ b/org.eclipse.handly.examples.jmodel/example.target
@@ -15,7 +15,7 @@
 <target name="JModel Example">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2024-09"/>
+<repository location="http://download.eclipse.org/releases/2024-12"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.handly.examples.xtext.xtext.ui/example.p2f
+++ b/org.eclipse.handly.examples.xtext.xtext.ui/example.p2f
@@ -16,7 +16,7 @@
   <ius size='1'>
     <iu id='org.eclipse.xtext.sdk.feature.group'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-09'/>
+        <repository location='http://download.eclipse.org/releases/2024-12'/>
       </repositories>
     </iu>
   </ius>

--- a/org.eclipse.handly.examples.xtext.xtext.ui/example.target
+++ b/org.eclipse.handly.examples.xtext.xtext.ui/example.target
@@ -15,7 +15,7 @@
 <target name="Xtext-Xtext Example">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2024-09"/>
+<repository location="http://download.eclipse.org/releases/2024-12"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.handly.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.handly.xtext.ui/META-INF/MANIFEST.MF
@@ -12,8 +12,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.22.0,4.0.0)",
  org.eclipse.handly;bundle-version="[1.7.0,2.0.0)",
  org.eclipse.handly.ui;bundle-version="[1.7.0,2.0.0)",
- org.eclipse.xtext.ui;bundle-version="[2.25.0,2.37.0)",
- org.eclipse.xtext.common.types;bundle-version="[2.25.0,2.37.0)";resolution:=optional,
+ org.eclipse.xtext.ui;bundle-version="[2.25.0,2.38.0)",
+ org.eclipse.xtext.common.types;bundle-version="[2.25.0,2.38.0)";resolution:=optional,
  org.eclipse.ui.ide;bundle-version="[3.18.0,4.0.0)"
 Export-Package: org.eclipse.handly.xtext.ui.callhierarchy,
  org.eclipse.handly.xtext.ui.editor,

--- a/targets/latest/latest.target
+++ b/targets/latest/latest.target
@@ -19,7 +19,7 @@
 <repository location="https://download.eclipse.org/cbi/updates/license/2.0.2.v20181016-2210"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="https://download.eclipse.org/releases/2024-09/202409111000/"/>
+<repository location="https://download.eclipse.org/releases/2024-12/202412041000/"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.mwe.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="0.0.0"/>

--- a/tools/latest.p2f
+++ b/tools/latest.p2f
@@ -2,39 +2,39 @@
 <?p2f version='1.0.0'?>
 <p2f version='1.0.0'>
   <ius size='7'>
-    <iu id='org.eclipse.sdk.ide' version='4.33.0.I20240903-0240'>
+    <iu id='org.eclipse.sdk.ide' version='4.34.0.I20241120-1800'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-09/'/>
+        <repository location='http://download.eclipse.org/releases/2024-12/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.egit.feature.group' version='7.0.0.202409031743-r'>
+    <iu id='org.eclipse.egit.feature.group' version='7.1.0.202411261347-r'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-09/'/>
+        <repository location='http://download.eclipse.org/releases/2024-12/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.m2e.feature.feature.group' version='2.6.2.20240828-1954'>
+    <iu id='org.eclipse.m2e.feature.feature.group' version='2.7.0.20241126-1642'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-09/'/>
+        <repository location='http://download.eclipse.org/releases/2024-12/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.xtext.sdk.feature.group' version='2.36.0.v20240825-0714'>
+    <iu id='org.eclipse.xtext.sdk.feature.group' version='2.37.0.v20241119-0857'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-09/'/>
+        <repository location='http://download.eclipse.org/releases/2024-12/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.emf.mwe.sdk.feature.group' version='1.13.0.v20240823-1107'>
+    <iu id='org.eclipse.emf.mwe.sdk.feature.group' version='1.14.0.v20241116-0534'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-09/'/>
+        <repository location='http://download.eclipse.org/releases/2024-12/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.emf.mwe2.language.sdk.feature.group' version='2.19.0.v20240823-1107'>
+    <iu id='org.eclipse.emf.mwe2.language.sdk.feature.group' version='2.20.0.v20241116-0534'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-09/'/>
+        <repository location='http://download.eclipse.org/releases/2024-12/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.emf.sdk.feature.group' version='2.39.0.v20240731-0952'>
+    <iu id='org.eclipse.emf.sdk.feature.group' version='2.40.0.v20241018-1213'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-09/'/>
+        <repository location='http://download.eclipse.org/releases/2024-12/'/>
       </repositories>
     </iu>
   </ius>


### PR DESCRIPTION
This is a cherry-pick of https://github.com/eclipse-handly/handly/pull/3 to 1.7.x.