### PR TITLE
Upgrade latest target to 2025-03 (1.7.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         java-version: |
           11
-          17
+          21
         distribution: 'temurin'
         cache: 'maven'
         cache-dependency-path: |
@@ -39,7 +39,7 @@ jobs:
       with:
         java-version: |
           11
-          17
+          21
         distribution: 'temurin'
         cache: 'maven'
         cache-dependency-path: |

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -41,11 +41,11 @@ ANTLR Runtime 3.2
 
  * License: BSD-3-Clause
 
-Apache Commons Logging 1.3.4
+Apache Commons Logging 1.3.5
 
  * License: Apache-2.0
 
-Google Guava 33.3.1
+Google Guava 33.4.0
 
  * License: Apache-2.0
 
@@ -61,6 +61,6 @@ hamcrest-core 3.0
 
  * License: BSD-3-Clause
 
-reload4j 1.2.25
+reload4j 1.2.26
 
  * License: Apache-2.0

--- a/org.eclipse.handly.examples.adapter/example.target
+++ b/org.eclipse.handly.examples.adapter/example.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2018, 2024 1C-Soft LLC.
+   Copyright (c) 2018, 2025 1C-Soft LLC.
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@
 <target name="Adapter Example">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2024-12"/>
+<repository location="http://download.eclipse.org/releases/2025-03"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.handly.examples.basic.ui.tests/.launch/org.eclipse.handly.examples.basic.ui.tests.launch
+++ b/org.eclipse.handly.examples.basic.ui.tests/.launch/org.eclipse.handly.examples.basic.ui.tests.launch
@@ -33,7 +33,7 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.handly.examples.basic.ui.tests"/>

--- a/org.eclipse.handly.examples.basic/.launch/Generate Language Infrastructure (org.eclipse.handly.examples.basic).launch
+++ b/org.eclipse.handly.examples.basic/.launch/Generate Language Infrastructure (org.eclipse.handly.examples.basic).launch
@@ -16,7 +16,7 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21/"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher"/>
     <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="org.eclipse.handly.examples.basic"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="src/org/eclipse/handly/examples/basic/GenerateFoo.mwe2"/>

--- a/org.eclipse.handly.examples.basic/example.p2f
+++ b/org.eclipse.handly.examples.basic/example.p2f
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-   Copyright (c) 2018, 2024 1C-Soft LLC.
+   Copyright (c) 2018, 2025 1C-Soft LLC.
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,7 @@
   <ius size='1'>
     <iu id='org.eclipse.xtext.sdk.feature.group'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-12'/>
+        <repository location='http://download.eclipse.org/releases/2025-03'/>
       </repositories>
     </iu>
   </ius>

--- a/org.eclipse.handly.examples.basic/example.target
+++ b/org.eclipse.handly.examples.basic/example.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2018, 2024 1C-Soft LLC.
+   Copyright (c) 2018, 2025 1C-Soft LLC.
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@
 <target name="Basic Example">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2024-12"/>
+<repository location="http://download.eclipse.org/releases/2025-03"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.handly.examples.jmodel.tests/.launch/org.eclipse.handly.examples.jmodel.tests.launch
+++ b/org.eclipse.handly.examples.jmodel.tests/.launch/org.eclipse.handly.examples.jmodel.tests.launch
@@ -32,7 +32,7 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.handly.examples.jmodel.tests"/>

--- a/org.eclipse.handly.examples.jmodel/example.target
+++ b/org.eclipse.handly.examples.jmodel/example.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2018, 2024 1C-Soft LLC.
+   Copyright (c) 2018, 2025 1C-Soft LLC.
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@
 <target name="JModel Example">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2024-12"/>
+<repository location="http://download.eclipse.org/releases/2025-03"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.handly.examples.xtext.xtext.ui/example.p2f
+++ b/org.eclipse.handly.examples.xtext.xtext.ui/example.p2f
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-   Copyright (c) 2019, 2024 1C-Soft LLC.
+   Copyright (c) 2019, 2025 1C-Soft LLC.
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which is available at
@@ -16,7 +16,7 @@
   <ius size='1'>
     <iu id='org.eclipse.xtext.sdk.feature.group'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-12'/>
+        <repository location='http://download.eclipse.org/releases/2025-03'/>
       </repositories>
     </iu>
   </ius>

--- a/org.eclipse.handly.examples.xtext.xtext.ui/example.target
+++ b/org.eclipse.handly.examples.xtext.xtext.ui/example.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2019, 2024 1C-Soft LLC.
+   Copyright (c) 2019, 2025 1C-Soft LLC.
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which is available at
@@ -15,7 +15,7 @@
 <target name="Xtext-Xtext Example">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2024-12"/>
+<repository location="http://download.eclipse.org/releases/2025-03"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.handly.examples/.launch/Launch Runtime Eclipse.launch
+++ b/org.eclipse.handly.examples/.launch/Launch Runtime Eclipse.launch
@@ -21,7 +21,7 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms40M -Xmx1024M -Dorg.eclipse.swt.internal.carbon.smallFonts"/>

--- a/org.eclipse.handly.tests/.launch/org.eclipse.handly.tests.launch
+++ b/org.eclipse.handly.tests/.launch/org.eclipse.handly.tests.launch
@@ -36,7 +36,7 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.handly.tests"/>

--- a/org.eclipse.handly.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.handly.xtext.ui/META-INF/MANIFEST.MF
@@ -12,8 +12,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.22.0,4.0.0)",
  org.eclipse.handly;bundle-version="[1.7.0,2.0.0)",
  org.eclipse.handly.ui;bundle-version="[1.7.0,2.0.0)",
- org.eclipse.xtext.ui;bundle-version="[2.25.0,2.38.0)",
- org.eclipse.xtext.common.types;bundle-version="[2.25.0,2.38.0)";resolution:=optional,
+ org.eclipse.xtext.ui;bundle-version="[2.25.0,2.39.0)",
+ org.eclipse.xtext.common.types;bundle-version="[2.25.0,2.39.0)";resolution:=optional,
  org.eclipse.ui.ide;bundle-version="[3.18.0,4.0.0)"
 Export-Package: org.eclipse.handly.xtext.ui.callhierarchy,
  org.eclipse.handly.xtext.ui.editor,

--- a/targets/latest/latest.target
+++ b/targets/latest/latest.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-   Copyright (c) 2014, 2024 1C-Soft LLC and others.
+   Copyright (c) 2014, 2025 1C-Soft LLC and others.
 
    This program and the accompanying materials are made available under
    the terms of the Eclipse Public License 2.0 which is available at
@@ -19,7 +19,7 @@
 <repository location="https://download.eclipse.org/cbi/updates/license/2.0.2.v20181016-2210"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="https://download.eclipse.org/releases/2024-12/202412041000/"/>
+<repository location="https://download.eclipse.org/releases/2025-03/202503121000/"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.mwe.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="0.0.0"/>

--- a/tools/latest.p2f
+++ b/tools/latest.p2f
@@ -2,39 +2,39 @@
 <?p2f version='1.0.0'?>
 <p2f version='1.0.0'>
   <ius size='7'>
-    <iu id='org.eclipse.sdk.ide' version='4.34.0.I20241120-1800'>
+    <iu id='org.eclipse.sdk.ide' version='4.35.0.I20250228-0140'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-12/'/>
+        <repository location='http://download.eclipse.org/releases/2025-03/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.egit.feature.group' version='7.1.0.202411261347-r'>
+    <iu id='org.eclipse.egit.feature.group' version='7.2.0.202503040940-r'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-12/'/>
+        <repository location='http://download.eclipse.org/releases/2025-03/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.m2e.feature.feature.group' version='2.7.0.20241126-1642'>
+    <iu id='org.eclipse.m2e.feature.feature.group' version='2.8.0.20250224-0720'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-12/'/>
+        <repository location='http://download.eclipse.org/releases/2025-03/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.xtext.sdk.feature.group' version='2.37.0.v20241119-0857'>
+    <iu id='org.eclipse.xtext.sdk.feature.group' version='2.38.0.v20250226-0658'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-12/'/>
+        <repository location='http://download.eclipse.org/releases/2025-03/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.emf.mwe.sdk.feature.group' version='1.14.0.v20241116-0534'>
+    <iu id='org.eclipse.emf.mwe.sdk.feature.group' version='1.15.0.v20250222-0818'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-12/'/>
+        <repository location='http://download.eclipse.org/releases/2025-03/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.emf.mwe2.language.sdk.feature.group' version='2.20.0.v20241116-0534'>
+    <iu id='org.eclipse.emf.mwe2.language.sdk.feature.group' version='2.21.0.v20250222-0818'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-12/'/>
+        <repository location='http://download.eclipse.org/releases/2025-03/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.emf.sdk.feature.group' version='2.40.0.v20241018-1213'>
+    <iu id='org.eclipse.emf.sdk.feature.group' version='2.41.0.v20241204-1554'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2024-12/'/>
+        <repository location='http://download.eclipse.org/releases/2025-03/'/>
       </repositories>
     </iu>
   </ius>


### PR DESCRIPTION
This is a cherry-pick of https://github.com/eclipse-handly/handly/pull/8 to 1.7.x.