### PR TITLE
Upgrade latest target to 2025-09 respin (1.7.x)

### DIFF
--- a/targets/latest/latest.target
+++ b/targets/latest/latest.target
@@ -19,7 +19,7 @@
 <repository location="https://download.eclipse.org/cbi/updates/license/2.0.2.v20181016-2210"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="https://download.eclipse.org/releases/2025-09/202509101000/"/>
+<repository location="https://download.eclipse.org/releases/2025-09/202509101001/"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.mwe.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="0.0.0"/>

--- a/tools/latest.p2f
+++ b/tools/latest.p2f
@@ -2,7 +2,7 @@
 <?p2f version='1.0.0'?>
 <p2f version='1.0.0'>
   <ius size='7'>
-    <iu id='org.eclipse.sdk.ide' version='4.37.0.I20250828-0630'>
+    <iu id='org.eclipse.sdk.ide' version='4.37.0.I20250905-0730'>
       <repositories size='1'>
         <repository location='http://download.eclipse.org/releases/2025-09/'/>
       </repositories>


### PR DESCRIPTION
This is a cherry-pick of #18 to 1.7.x.