### PR TITLE
Upgrade latest target to 2026-06 (1.7.x)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -41,11 +41,11 @@ ANTLR Runtime 3.2
 
  * License: BSD-3-Clause
 
-Apache Commons Logging 1.3.5
+Apache Commons Logging 1.3.6
 
  * License: Apache-2.0
 
-Google Guava 33.5.0
+Google Guava 33.6.0
 
  * License: Apache-2.0
 

--- a/org.eclipse.handly.examples.adapter/example.target
+++ b/org.eclipse.handly.examples.adapter/example.target
@@ -15,7 +15,7 @@
 <target name="Adapter Example">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2026-03"/>
+<repository location="http://download.eclipse.org/releases/2026-06"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.handly.examples.basic/example.p2f
+++ b/org.eclipse.handly.examples.basic/example.p2f
@@ -16,7 +16,7 @@
   <ius size='1'>
     <iu id='org.eclipse.xtext.sdk.feature.group'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2026-03'/>
+        <repository location='http://download.eclipse.org/releases/2026-06'/>
       </repositories>
     </iu>
   </ius>

--- a/org.eclipse.handly.examples.basic/example.target
+++ b/org.eclipse.handly.examples.basic/example.target
@@ -15,7 +15,7 @@
 <target name="Basic Example">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2026-03"/>
+<repository location="http://download.eclipse.org/releases/2026-06"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.handly.examples.jmodel/example.target
+++ b/org.eclipse.handly.examples.jmodel/example.target
@@ -15,7 +15,7 @@
 <target name="JModel Example">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2026-03"/>
+<repository location="http://download.eclipse.org/releases/2026-06"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">

--- a/org.eclipse.handly.examples.xtext.xtext.ui/example.p2f
+++ b/org.eclipse.handly.examples.xtext.xtext.ui/example.p2f
@@ -16,7 +16,7 @@
   <ius size='1'>
     <iu id='org.eclipse.xtext.sdk.feature.group'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2026-03'/>
+        <repository location='http://download.eclipse.org/releases/2026-06'/>
       </repositories>
     </iu>
   </ius>

--- a/org.eclipse.handly.examples.xtext.xtext.ui/example.target
+++ b/org.eclipse.handly.examples.xtext.xtext.ui/example.target
@@ -15,7 +15,7 @@
 <target name="Xtext-Xtext Example">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="http://download.eclipse.org/releases/2026-03"/>
+<repository location="http://download.eclipse.org/releases/2026-06"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>

--- a/org.eclipse.handly.xtext.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.handly.xtext.ui/META-INF/MANIFEST.MF
@@ -12,8 +12,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.22.0,4.0.0)",
  org.eclipse.handly;bundle-version="[1.7.0,2.0.0)",
  org.eclipse.handly.ui;bundle-version="[1.7.0,2.0.0)",
- org.eclipse.xtext.ui;bundle-version="[2.25.0,2.43.0)",
- org.eclipse.xtext.common.types;bundle-version="[2.25.0,2.43.0)";resolution:=optional,
+ org.eclipse.xtext.ui;bundle-version="[2.25.0,2.44.0)",
+ org.eclipse.xtext.common.types;bundle-version="[2.25.0,2.44.0)";resolution:=optional,
  org.eclipse.ui.ide;bundle-version="[3.18.0,4.0.0)"
 Export-Package: org.eclipse.handly.xtext.ui.callhierarchy,
  org.eclipse.handly.xtext.ui.editor,

--- a/targets/latest/latest.target
+++ b/targets/latest/latest.target
@@ -19,7 +19,7 @@
 <repository location="https://download.eclipse.org/cbi/updates/license/2.0.2.v20181016-2210"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<repository location="https://download.eclipse.org/releases/2026-03/202603111000/"/>
+<repository location="https://download.eclipse.org/releases/2026-06/202606101000/"/>
 <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.mwe.sdk.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="0.0.0"/>

--- a/tools/latest.p2f
+++ b/tools/latest.p2f
@@ -2,39 +2,39 @@
 <?p2f version='1.0.0'?>
 <p2f version='1.0.0'>
   <ius size='7'>
-    <iu id='org.eclipse.sdk.ide' version='4.39.0.I20260226-0420'>
+    <iu id='org.eclipse.sdk.ide' version='4.40.0.I20260601-0713'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2026-03/'/>
+        <repository location='http://download.eclipse.org/releases/2026-06/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.egit.feature.group' version='7.6.0.202603022253-r'>
+    <iu id='org.eclipse.egit.feature.group' version='7.7.0.202606012155-r'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2026-03/'/>
+        <repository location='http://download.eclipse.org/releases/2026-06/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.m2e.feature.feature.group' version='2.10.100.20260205-1611'>
+    <iu id='org.eclipse.m2e.feature.feature.group' version='2.10.200.20260602-0749'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2026-03/'/>
+        <repository location='http://download.eclipse.org/releases/2026-06/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.xtext.sdk.feature.group' version='2.42.0.v20260223-0608'>
+    <iu id='org.eclipse.xtext.sdk.feature.group' version='2.43.0.v20260525-1205'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2026-03/'/>
+        <repository location='http://download.eclipse.org/releases/2026-06/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.emf.mwe.sdk.feature.group' version='1.19.0.v20260221-0523'>
+    <iu id='org.eclipse.emf.mwe.sdk.feature.group' version='1.20.0.v20260523-1243'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2026-03/'/>
+        <repository location='http://download.eclipse.org/releases/2026-06/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.emf.mwe2.language.sdk.feature.group' version='2.25.0.v20260221-0523'>
+    <iu id='org.eclipse.emf.mwe2.language.sdk.feature.group' version='2.26.0.v20260523-1243'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2026-03/'/>
+        <repository location='http://download.eclipse.org/releases/2026-06/'/>
       </repositories>
     </iu>
-    <iu id='org.eclipse.emf.sdk.feature.group' version='2.45.0.v20260127-0058'>
+    <iu id='org.eclipse.emf.sdk.feature.group' version='2.46.0.v20260425-0820'>
       <repositories size='1'>
-        <repository location='http://download.eclipse.org/releases/2026-03/'/>
+        <repository location='http://download.eclipse.org/releases/2026-06/'/>
       </repositories>
     </iu>
   </ius>


### PR DESCRIPTION
This is a cherry-pick of #30 to 1.7.x.